### PR TITLE
Fix for terraform 0.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.terraform/
+terraform.*

--- a/main.tf
+++ b/main.tf
@@ -90,11 +90,11 @@ resource "aws_security_group" "default" {
 }
 
 resource "aws_spot_instance_request" "web" {
-    spot_price = "${lookup(var.spot_prices, var.instance_types.web)}"
+    spot_price = "${lookup(var.spot_prices, lookup(var.instance_types, "web"))}"
     wait_for_fulfillment = "${var.wait_for_fulfillment}"
 
-    ami = "${var.amis.web}"
-    instance_type = "${var.instance_types.web}"
+    ami = "${lookup(var.amis, "web")}"
+    instance_type = "${lookup(var.instance_types, "web")}"
     key_name = "${aws_key_pair.default.key_name}"
     vpc_security_group_ids = ["${aws_security_group.default.id}"]
     subnet_id = "${aws_subnet.default.id}"
@@ -106,11 +106,11 @@ resource "aws_spot_instance_request" "web" {
 }
 
 resource "aws_spot_instance_request" "bench" {
-    spot_price = "${lookup(var.spot_prices, var.instance_types.bench)}"
+    spot_price = "${lookup(var.spot_prices, lookup(var.instance_types, "bench"))}"
     wait_for_fulfillment = "${var.wait_for_fulfillment}"
 
-    ami = "${var.amis.bench}"
-    instance_type = "${var.instance_types.bench}"
+    ami = "${lookup(var.amis, "bench")}"
+    instance_type = "${lookup(var.instance_types, "bench")}"
     key_name = "${aws_key_pair.default.key_name}"
     vpc_security_group_ids = ["${aws_security_group.default.id}"]
     subnet_id = "${aws_subnet.default.id}"


### PR DESCRIPTION
Terraform v0.10.0 にて動かない箇所があったので修正しました

- `var.foo.bar` のような書き方ができなくなっていたので修正 dabdd1f

  > You now access the values of maps using the syntax var.map["key"] or the lookup function instead of var.map.key.
  > https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#070-august-2-2016

- `terraform init` コマンド実行時に AWS 関連の plugin が `.terraform/` ディレクトリ以下にダウンロードされるので `.gitignore` で git の管理から外しました 4f2d2da
  - 同じくローカルの `.tfstate` ファイルも外しました